### PR TITLE
PULL_REQUEST_TEMPLATE의 항목수를 줄임

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,12 +3,8 @@
 - [ ]
 
 ### このPRが処理するissue
-https://github.com/crane93/Issue-Maker/issues/
 
 ### 説明
-
-### ステータス
-**READY/IN DEVELOPMENT/HOLD/END**
 
 ### 結果イメージ
 
@@ -20,13 +16,8 @@ https://github.com/crane93/Issue-Maker/issues/
 - [ ]
 
 ### 이 PR 처리하는 issue
-https://github.com/crane93/Issue-Maker/issues/
 
 ### 설명
-
-
-### 진행상황
-**READY/IN DEVELOPMENT/HOLD/END**
 
 ### 구현이미지
 


### PR DESCRIPTION
### 이 PR에서 할 일
- [x] `진행상황` , `이 PR 처리하는 issue` 의 내용부분 삭제

### 설명
- 진행상황은 Labels에서 표현하고 있으니 중복이라고 생각합니다.
- `이 PR 처리하는 issue` 의 내용은 브라우저에서 복사할때 모든 부분을 선택하고 복사하기때문에 공백으로 두는편이 좋다고 생각합니다.

### 구현이미지
딱히 없음
